### PR TITLE
优化: 一言开关,静态资源引用方式,单页面.新增51 LA统计

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,10 +21,14 @@ publishDir            = "docs"					# 站点静态文件保存目录
     logosPath     = "assets/images/logos"			# 网站每个导航地址logo存放地址
     defaultLogo   = "assets/images/logos/default.webp"		# logo图片资源不存在或者错误时, 默认显示的logo; 该参数如为空,将会一直加载对应的logo,直至成功
     nightMode     = true					# 默认站点为深色(夜间)模式
+    yiyan         = true                         # 一言
 
 [params.seo]    
     baiduhmid     = 'efccc04cb44fc49faddac5876180b369'		# 百度统计 hm.src 的 ID
     baiduSiteVer  = 'codeva-cCAOSG8MBO'				# 百度HTML标签验证(baidu-site-verification)
+
+    tj51laid        = ''                        # 51.LA 网站统计
+    tj51lack        = ''
 
 [params.qweather]
     key = "085791e805a24491b43b06cf58ab31e7"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,11 +6,25 @@
     <main role="main" class="flex-shrink-0">
     <div class="container">
         <h1 class="mt-5">{{ .Title }}</h1>
-        <p class="lead">
-        {{ .Content | markdownify | safeHTML }}
-        </p>
+        <div class="content">
+            {{ .Content | markdownify | safeHTML }}
+        </div>
     </div>
     </main>
+
+    <style>
+        .content {
+            font-size: 1.25rem;
+          }
+          
+          .content h1,
+          .content h2,
+          .content h3,
+          .content h4 {
+            margin: 15px 10px 5px;
+          }
+          
+    </style>
 
 {{ partial "content_footer.html" . }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,112 +1,17 @@
-<!DOCTYPE html>
-<html lang="zh-CN">
+{{ partial "header.html" . }}
 
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="author" content="viggo" />
-    <title>{{ .Site.Title }}</title>
-    <meta name="keywords" content="Webstack Hugo theme">
-    <meta name="description" content="Webstack Hugo theme">
-    <link rel="shortcut icon" href="../assets/images/favicon.png">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Arimo:400,700,400italic">
-    <link rel="stylesheet" href="../assets/css/fonts/linecons/css/linecons.css">
-    <link rel="stylesheet" href="../assets/css/fonts/fontawesome/css/font-awesome.min.css">
-    <link rel="stylesheet" href="../assets/css/bootstrap.css">
-    <link rel="stylesheet" href="../assets/css/xenon-core.css">
-    <link rel="stylesheet" href="../assets/css/xenon-components.css">
-    <link rel="stylesheet" href="../assets/css/xenon-skins.css">
-    <link rel="stylesheet" href="../assets/css/nav.css">
-    <link rel="stylesheet" href="../assets/css/custom-style.css">
-    <script src="../assets/js/jquery-1.11.1.min.js"></script>
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-        <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
-    <!-- / FB Open Graph -->
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="">
-    <meta property="og:title" content="">
-    <meta property="og:description" content="">
-    <meta property="og:image" content="">
-    <meta property="og:site_name" content="">
-    <!-- / Twitter Cards -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="">
-    <meta name="twitter:description" content="">
-    <meta name="twitter:image" content="">
-    <script>
-        var _hmt = _hmt || [];
-        (function() {
-          var hm = document.createElement("script");
-          hm.src = "https://hm.baidu.com/hm.js?86cead3bcab6a1417189e6138d69262";
-          var s = document.getElementsByTagName("script")[0]; 
-          s.parentNode.insertBefore(hm, s);
-        })();
-    </script>
-</head>
+{{ partial "content_header.html" . }}
 
 <body class="page-body boxed-container">
-    <nav class="navbar horizontal-menu navbar-fixed-top">
-        <div class="navbar-inner">
-            <div class="navbar-brand">
-                <a href="../index.html" class="logo">
-                    {{ if hasPrefix $.Site.Params.images.logoExpandLight "http" }}
-                    <img src="{{ $.Site.Params.images.logoExpandLight }}" width="100%" alt="" class="hidden-xs">
-                    {{ else }}
-                    <img src="../{{ $.Site.Params.images.logoExpandLight }}" width="100%" alt="" class="hidden-xs">
-                    {{ end }}
-                </a>
-            </div>
-            <div class="navbar-mobile-clear"></div>
-            <a href="{{ $.Site.Params.repository }}" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="../assets/images/forkme_on_github_right_darkblue.png" alt="Fork me on GitHub"></a>
-        </div>
-    </nav>
-    <div class="page-container">
-        <!-- add class "sidebar-collapsed" to close sidebar by default, "chat-visible" to make chat appear always -->
-        <div class="main-content" style="">
-            <div class="row">
-                <div class="col-md-12">
-                    <div class="panel panel-default">
-                        <!-- 关于网站 -->
-                        <h4 class="text-gray">{{ .Title }}</h4>
-                        <div class="panel-body">
-                            <div class="row">
-                                <div class="col-sm-12">
-                                    {{ .Content | markdownify | safeHTML }}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <!-- Main Footer -->
-            <footer class="main-footer sticky footer-type-1 fixed">
-                <div class="footer-inner">
-                    <div class="footer-text">
-                        <strong>{{ if $.Site.Params.footer.copyright }}{{ replace $.Site.Params.footer.copyright "{year}" now.Year | markdownify }}{{ else }}BioIT 爱好者{{ end }}</strong> Design by <a href="http://viggoz.com" target="_blank"><strong>Viggo</strong></a> themes by <a href="{{ $.Site.Params.repository }}" target="_blank"><strong>shenweiyan</strong></a>
-                    </div>
-                    <div class="go-up">
-                        <a href="#" rel="go-top">
-                            <i class="fa-angle-up"></i>
-                        </a>
-                    </div>
-                </div>
-            </footer>
-        </div>
+    <main role="main" class="flex-shrink-0">
+    <div class="container">
+        <h1 class="mt-5">{{ .Title }}</h1>
+        <p class="lead">
+        {{ .Content | markdownify | safeHTML }}
+        </p>
     </div>
-    <!-- Bottom Scripts -->
-    <script src="../assets/js/bootstrap.min.js"></script>
-    <script src="../assets/js/TweenMax.min.js"></script>
-    <script src="../assets/js/resizeable.js"></script>
-    <script src="../assets/js/joinable.js"></script>
-    <script src="../assets/js/xenon-api.js"></script>
-    <script src="../assets/js/xenon-toggles.js"></script>
-    <!-- JavaScripts initializations and stuff -->
-    <script src="../assets/js/xenon-custom.js"></script>
-    <textarea tabindex="-1" style="position: absolute; top: -999px; left: 0px; right: auto; bottom: auto; border: 0px; padding: 0px; box-sizing: content-box; word-wrap: break-word; overflow: hidden; transition: none; height: 0px !important; min-height: 0px !important; font-family: Arimo, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 400; font-style: normal; letter-spacing: 0px; text-transform: none; word-spacing: 0px; text-indent: 0px; line-height: 18.5714px; width: 53px;" class="autosizejs" id="autosizejs"></textarea>
-</body>
+    </main>
 
-</html>
+{{ partial "content_footer.html" . }}
+
+{{ partial "footer.html" . }}

--- a/layouts/partials/content_header.html
+++ b/layouts/partials/content_header.html
@@ -5,9 +5,9 @@
                 <div class="container-fluid p-0">
 
                     <a href="" class="navbar-brand d-md-none" title="{{ .Site.Title }}">
-                        <img src="{{ $.Site.Params.images.logoCollapseLight }}" class="logo-light"
+                        <img src="{{ relURL $.Site.Params.images.logoCollapseLight }}" class="logo-light"
                             alt="{{ .Site.Title }}">
-                        <img src="{{ $.Site.Params.images.logoCollapseDark }}" class="logo-dark d-none"
+                        <img src="{{ relURL $.Site.Params.images.logoCollapseDark }}" class="logo-dark d-none"
                             alt="{{ .Site.Title }}">
                     </a>
 
@@ -62,7 +62,7 @@
                                         "fixed": "false",
                                         "vertical": "middle",
                                         "horizontal": "left",
-                                        "key": {{ $.Site.Params.qweather.key }}
+                                        "key": "{{ $.Site.Params.qweather.key }}"
                                     }
                                 }
                             </script>
@@ -73,6 +73,7 @@
 
                     <ul class="nav navbar-menu text-xs order-1 order-md-2">
                         <!-- 一言 -->
+                        {{ with .Site.Params.yiyan }}
                         <li class="nav-item mr-3 mr-lg-0 d-none d-lg-block">
                             <script>
                                 fetch('https://v1.hitokoto.cn')
@@ -86,6 +87,7 @@
                             </script>                           
                             <div id="hitokoto"><a href="#" target="_blank" id="hitokoto_text">疏影横斜水清浅，暗香浮动月黄昏。</a></div>
                         </li>
+                        {{ end }}
                         <!-- 一言 end -->
                         <li class="nav-search ml-3 ml-md-4">
                             <a href="javascript:" data-toggle="modal" data-target="#search-modal"><i

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,21 +1,21 @@
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/jquery.ui.touch-punch.min-0.2.2.js' id='jqueryui-touch-js'></script>
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/clipboard.min-5.6.2.js' id='clipboard-js'></script>
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/tooltip-extend.js' id='iplaycode-nav-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/jquery.ui.touch-punch.min-0.2.2.js" }}' id='jqueryui-touch-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/clipboard.min-5.6.2.js" }}' id='clipboard-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/tooltip-extend.js" }}' id='iplaycode-nav-js'></script>
 <script type='text/javascript' id='popper-js-extra'>
 /* <![CDATA[ */
 //var theme = {"ajaxurl":"https:\/\/nav.baidu.com\/wp-admin\/admin-ajax.php","addico":"https:\/\/nav.baidu.cn\/wp-content\/themes\/onenav\/images\/add.png","order":"asc","formpostion":"top","defaultclass":"io-grey-mode","isCustomize":"1","icourl":"https:\/\/api.badi.cn\/favicon\/","icopng":".png","urlformat":"1","customizemax":"10","newWindow":"0","lazyload":"1","minNav":"1","loading":"1","hotWords":"baidu","classColumns":" col-sm-6 col-md-4 col-xl-5a col-xxl-6a ","apikey":"TWpBeU1UVTNOekk1TWpVMEIvZ1M2bFVIQllUMmxsV1dZelkxQTVPVzB3UW04eldGQmxhM3BNWW14bVNtWk4="};
 var theme = {"ajaxurl":"","addico":"https:\/\/nav.baidu.cn\/wp-content\/themes\/onenav\/images\/add.png","order":"asc","formpostion":"top","defaultclass":"io-grey-mode","isCustomize":"1","icourl":"","icopng":".png","urlformat":"1","customizemax":"10","newWindow":"0","lazyload":"1","minNav":"1","loading":"1","hotWords":"baidu","classColumns":" col-sm-6 col-md-4 col-xl-5a col-xxl-6a ","apikey":"TWpBeU1UVTNOekk1TWpVMEIvZ1M2bFVIQllUMmxsV1dZelkxQTVPVzB3UW04eldGQmxhM3BNWW14bVNtWk4="};
 /* ]]> */
 </script>
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/popper.min.js' id='popper-js'></script>
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/bootstrap.min-4.3.1.js' id='bootstrap-js'></script>
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/theia-sticky-sidebar-1.5.0.js' id='sidebar-js'></script>
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/lazyload.min-12.4.0.js' id='lazyload-js'></script>
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/fancybox.min-3.5.7.js' id='lightbox-js-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/popper.min.js" }}' id='popper-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/bootstrap.min-4.3.1.js" }}' id='bootstrap-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/theia-sticky-sidebar-1.5.0.js" }}' id='sidebar-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/lazyload.min-12.4.0.js" }}' id='lazyload-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/fancybox.min-3.5.7.js" }}' id='lightbox-js-js'></script>
 {{ if $.Site.Params.expandSidebar }}
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/app-anim.js' id='appanim-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/app-anim.js" }}' id='appanim-js'></script>
 {{ else }}
-<script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/app-mini.js' id='appmini-js'></script>
+<script type='text/javascript' src='{{ relURL "/assets/js/app-mini.js" }}' id='appmini-js'></script>
 {{ end }}
 <script type="text/javascript">
     $(document).ready(function(){
@@ -120,6 +120,5 @@ function switchNightMode(){
     }
 }
 </script>
-
 </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,34 +1,53 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
+
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <meta name="theme-color" content="#f9f9f9">
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1" />
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="theme-color" content="#f9f9f9" />
     <title>{{ .Site.Title }}</title>
-    <link rel="shortcut icon" href="{{ $.Site.Params.images.favicon }}">
-    <meta name="keywords" content="{{ .Site.Title }}">
+    <link rel="shortcut icon" href="{{ relURL $.Site.Params.images.favicon }}" />
+    <meta name="keywords" content="{{ .Site.Title }}" />
     {{ if $.Site.Params.seo.baiduSiteVer }}
     <meta name="baidu-site-verification" content="{{ $.Site.Params.seo.baiduSiteVer }}" />
     {{ end }}
-    <link rel='stylesheet' id='block-library-css' href='{{ $.Site.Params.siteurl }}/assets/css/block-library.min-5.6.2.css' type='text/css' media='all'>
-    <link rel='stylesheet' id='iconfont-css' href='{{ $.Site.Params.siteurl }}/assets/css/iconfont-3.03029.1.css' type='text/css' media='all'>
-    <link rel='stylesheet' id='bootstrap-css' href='{{ $.Site.Params.siteurl }}/assets/css/bootstrap.min-4.3.1.css' type='text/css' media='all'>
-    <link rel='stylesheet' id='fancybox-css' href='{{ $.Site.Params.siteurl }}/assets/css/fancybox.min-3.5.7.css' type='text/css' media='all'>
-    <link rel='stylesheet' id='iowen-css' href='{{ $.Site.Params.siteurl }}/assets/css/style-3.03029.1.css' type='text/css' media='all'>
-    <link rel='stylesheet' id='custom-css' href='{{ $.Site.Params.siteurl }}/assets/css/custom-style.css' type='text/css' media='all'>
-    <link rel="stylesheet" id="fortawesome-css" href="{{ $.Site.Params.siteurl }}/assets/fontawesome-5.15.4/css/all.min.css" type="text/css">
-    <script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/jquery.min-3.2.1.js' id='jquery-js'></script>
-    <script type='text/javascript' src='{{ $.Site.Params.siteurl }}/assets/js/content-search.js' id='content-search-js'></script>
+    <link rel="stylesheet" id="block-library-css"
+        href="{{ relURL "/assets/css/block-library.min-5.6.2.css" }}" type="text/css" media="all" />
+    <link rel="stylesheet" id="iconfont-css" href="{{ relURL "/assets/css/iconfont-3.03029.1.css" }}"
+        type="text/css" media="all" />
+    <link rel="stylesheet" id="bootstrap-css" href="{{ relURL "/assets/css/bootstrap.min-4.3.1.css" }}"
+        type="text/css" media="all" />
+    <link rel="stylesheet" id="fancybox-css" href="{{ relURL "/assets/css/fancybox.min-3.5.7.css" }}"
+        type="text/css" media="all" />
+    <link rel="stylesheet" id="iowen-css" href="{{ relURL "/assets/css/style-3.03029.1.css" }}"
+        type="text/css" media="all" />
+    <link rel="stylesheet" id="custom-css" href="{{ relURL "/assets/css/custom-style.css" }}"
+        type="text/css" media="all" />
+    <link rel="stylesheet" id="fortawesome-css"
+        href="{{ relURL "/assets/fontawesome-5.15.4/css/all.min.css" }}" type="text/css" />
+    <script type="text/javascript" src="{{ relURL "/assets/js/jquery.min-3.2.1.js" }}"
+        id="jquery-js"></script>
+    <script type="text/javascript" src="{{ relURL "/assets/js/content-search.js" }}"
+        id="content-search-js"></script>
     <!-- 百度统计 -->
     <script>
-        var _hmt = _hmt || [];
-        (function () {
-            var hm = document.createElement("script");
-            hm.src = "https://hm.baidu.com/hm.js?{{ $.Site.Params.seo.baiduhmid }}";
-            var s = document.getElementsByTagName("script")[0];
-            s.parentNode.insertBefore(hm, s);
-        })();
+        {{ with .Site.Params.seo.baiduhmid }}
+        var _hmt = _hmt || []
+            (function () {
+                var hm = document.createElement("script")
+                hm.src = "https://hm.baidu.com/hm.js?{{ $.Site.Params.seo.baiduhmid }}"
+                var s = document.getElementsByTagName("script")[0]
+                s.parentNode.insertBefore(hm, s)
+            })()
+        {{ end }}
     </script>
-    <!-- end 百度统计 -->   
+    <!-- end 百度统计 -->
+    <!-- 51.LA 网站统计 -->
+    {{ with .Site.Params.seo.tj51laid }}
+    <script charset="UTF-8" id="LA_COLLECT" src="//sdk.51.la/js-sdk-pro.min.js"></script>
+    <script>LA.init({id:"{{ $.Site.Params.seo.tj51laid }}",ck:"{{ $.Site.Params.seo.tj51lack }}"})</script>    
+    {{ end }} 
+    <!-- end 51.LA 网站统计 -->
 </head>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -74,15 +74,15 @@
                     <!-- logo -->
                     <div class="logo overflow-hidden">
                         <a href="" class="logo-expanded">
-                            <img src="{{ $.Site.Params.images.logoExpandLight }}" height="40" class="logo-light"
+                            <img src="{{ relURL $.Site.Params.images.logoExpandLight }}" height="40" class="logo-light"
                                 alt="{{ .Site.Title }}">
-                            <img src="{{ $.Site.Params.images.logoExpandDark }}" height="40" class="logo-dark d-none"
+                            <img src="{{ relURL $.Site.Params.images.logoExpandDark }}" height="40" class="logo-dark d-none"
                                 alt="{{ .Site.Title }}">
                         </a>
                         <a href="" class="logo-collapsed">
-                            <img src="{{ $.Site.Params.images.logoCollapseLight }}" height="40" class="logo-light"
+                            <img src="{{ relURL $.Site.Params.images.logoCollapseLight }}" height="40" class="logo-light"
                                 alt="{{ .Site.Title }}">
-                            <img src="{{ $.Site.Params.images.logoCollapseDark }}" height="40" class="logo-dark d-none"
+                            <img src="{{ relURL $.Site.Params.images.logoCollapseDark }}" height="40" class="logo-dark d-none"
                                 alt="{{ .Site.Title }}">
                         </a>
                     </div>


### PR DESCRIPTION
1. 新增一言开关
2. 新增 51.LA 统计
3. 优化百度统计：无统计 ID 时不引入相关的 JS
4. 单页面的样式修改
5. 静态资源引用的方式

官方提供的 `with`，已经可以判断空值、无值和 0   
https://gohugo.io/functions/with/

官方提供的 `relURL`，可以取得相对路径   
https://gohugo.io/functions/relurl/

文档中，可以直接使用 `WebStack-Hugo` 默认的主题，所以功能参数支持定制化相对好些，这样的话，可以实时从主仓库拉取更新。   
https://gohugo.io/getting-started/quick-start/#commands

我的做法是：
```bash
# 创建项目
mkdir navsites
cd $_

# 初始化项目
git init

# 将 WebStack-Hugo 源下载到 themes/WebStack-Hugo 文件夹
git submodule add https://github.com/shenweiyan/WebStack-Hugo.git themes/WebStack-Hugo
cp -r themes/WebStack-Hugo/exampleSite/* ./

# 安装 hugo
go install github.com/gohugoio/hugo@latest

# 本地测试
hugo server

# 生成 docs 文件夹，将并静态内容生成至此处
hugo -D
```
以后有更新的时候，直接进入 `themes/WebStack-Hugo`，从 `https://github.com/shenweiyan/WebStack-Hugo.git` 拉取源码即可。