### PR TITLE
添加多语言支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 - 站点：[https://bioit.top](https://bioit.top)
 - 源码：<https://github.com/shenweiyan/NavBioIT>
 
-
 ## 特色功能
 
 这是 Hugo 版 WebStack 主题。可以借助下面的平台直接托管部署，无需服务器。
@@ -41,11 +40,11 @@
     - term: 云服务器
       links:
         - title: 阿里云
-          logo: 阿里云.jpg
+          logo: 阿里云。jpg
           url: https://www.aliyun.com/
           description: 上云就上阿里云。
         - title: 腾讯云
-          logo: 腾讯云.jpg
+          logo: 腾讯云。jpg
           url: https://cloud.tencent.com/
           description: 产业智变，云启未来。
 ```
@@ -53,22 +52,38 @@
 - 增加了搜索功能，以及下拉的热词选项（基于百度 API）。
 - 增加了一言、和风天气的 API。
 
+## 国际化
+
+在`config.toml`中使用不同语言的站点信息，如：
+
+```toml
+languageCode = "en-us"
+defaultContentLanguage = "en-us"
+```
+
+那么便需要在
+
+```toml
+[languages]
+  [languages.xxx]
+```
+
+中定义不同语言的站点信息，你也可以自定义新的语言。
+
 ## 使用说明
 
 这是一个开源的公益项目，你可以拿来制作自己的网址导航，也可以做与导航无关的网站。
 
 WebStack 有非常多的魔改版本，这是其中一个。如果你对本主题进行了一些个性化调整，欢迎来本项目中 [issue](https://github.com/shenweiyan/WebStack-Hugo/issues) 分享一下！
 
-
 ## 安装说明
 
 关于 Windows/Linux 下详细的安装与使用说明，请参考文档。
 
 > [!TIP] 
-> 链接1：**[shenweiyan/Knowledge-Garden#10](https://github.com/shenweiyan/Knowledge-Garden/discussions/10)**
+> 链接 1：**[shenweiyan/Knowledge-Garden#10](https://github.com/shenweiyan/Knowledge-Garden/discussions/10)**
 > 
-> 链接2：**<https://weiyan.cc/kg-discussions-10>**
-
+> 链接 2：**<https://weiyan.cc/kg-discussions-10>**
 
 ## 感谢
 
@@ -87,4 +102,3 @@ WebStack 有非常多的魔改版本，这是其中一个。如果你对本主�
 如果你觉得本项目对你有所帮助，欢迎请作者喝杯热咖啡 >.<
 
 ![donate-wecaht-aliapy](https://user-images.githubusercontent.com/26101369/212630361-aa393be8-581e-4a97-bfe2-256e883791fb.jpg)
-

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,12 +1,25 @@
 baseURL               = "https://bioit.top/"
-languageCode          = "zh-CN"
-title                 = "WebStack-Hugo 网址导航"
+languageCode = "en-us"
+defaultContentLanguage = "en-us"
 theme                 = "WebStack-Hugo"
 preserveTaxonomyNames = true
 disablePathToLower    = true
 hasCJKLanguage        = true
-publishDir            = "public"				# 站点静态文件保存目录
+publishDir            = "docs"
 
+[languages]
+  [languages.en-us]
+    title = "WebStack"
+    contentDir = "data/en-us"
+    textPreLoad   = "Website navigation"	                      # 预加载的动画文字, 只有当enablePreLoad=true时生效
+    [languages.en-us.params.footer]
+        copyright = 'The content on this site is sourced from the internet. If any content infringes on your rights, please contact us to remove the relevant material. Contact email: weiyanshum@foxmail.com <br/>&copy; 2021 - {year} By [WebStack-Hugo](https://github.com/shenweiyan/WebStack-Hugo) | [Bio IT Enthusiast](https://www.bioitee.com/) | [Yue ICP License 16023717](http://beian.miit.gov.cn/)<br/>'
+
+  [languages.zh-cn]
+    title = "网址导航"
+    textPreLoad   = "网址导航"	                                           # 预加载的动画文字, 只有当enablePreLoad=true时生效
+    [languages.zh-cn.params.footer]
+        copyright = '本站内容源自互联网，如有内容侵犯了你的权益，请联系删除相关内容，联系邮箱：weiyanshum@foxmail.com <br/>&copy; 2021 - {year} By [WebStack-Hugo](https://github.com/shenweiyan/WebStack-Hugo) | [Bio IT 爱好者](https://www.bioitee.com/) | [粤ICP备16023717号](http://beian.miit.gov.cn/)<br/>'
 
 [params]
     author        = "shenweiyan"
@@ -15,7 +28,6 @@ publishDir            = "public"				# 站点静态文件保存目录
     about         = "https://github.com/shenweiyan/Knowledge-Garden/discussions/10"	          # 左侧导航栏的"关于导航"页面(./about)
     repository    = "https://github.com/shenweiyan/WebStack-Hugo"  
     enablePreLoad = true					# 网站完全打开前预加载动画
-    textPreLoad   = "Hugo 网址导航主题"				# 预加载的动画文字, 只有当enablePreLoad=true时生效
     expandSidebar = false					# 默认展开左侧边导航栏
     logosPath     = "assets/images/logos"			# 网站每个导航地址logo存放地址
     defaultLogo   = "assets/images/logos/default.webp"		# logo图片资源不存在或者错误时, 默认显示的logo; 该参数如为空,将会一直加载对应的logo,直至成功
@@ -43,6 +55,3 @@ publishDir            = "public"				# 站点静态文件保存目录
     
 [markup.goldmark.renderer]
     unsafe = true
-
-[params.footer]
-    copyright = '本站内容源自互联网，如有内容侵犯了你的权益，请联系删除相关内容，联系邮箱：weiyanshum@foxmail.com <br/>&copy; 2021 - {year} By [WebStack-Hugo](https://github.com/shenweiyan/WebStack-Hugo) | [Bio IT 爱好者](https://www.bioitee.com/) | [粤ICP备16023717号](http://beian.miit.gov.cn/)<br/>'


### PR DESCRIPTION
我只对站点信息进行了简单的多语言支持，关于站内项目（即收录的网站信息）的多语言，hugo中默认的模板是通过

```toml
[languages.en]
  title = "XXXXX"
  contentDir = 'content/en-us'
```
中的contentDir来指向，但是本主题的站内项目并不指向content，所以您需要修改模板代码，如content_main.html中的{{ range .Site.Data.webstack }}，使其在不同语言时指向data目录下的不同语言的文件夹，从而实现多语言支持。

此外，建议您在首页添加多语言切换按钮，会更加完善。

关于图标，可以引入一些图标库，但是现有的图标库对生物数据库logo还有各类其它数据库logo的收录极少，所以建议您尝试使用iconfont图标库构建图标库，虽然繁琐，但是后续使用及其方便。
